### PR TITLE
support autodl

### DIFF
--- a/molink/distributed/parallel_state.py
+++ b/molink/distributed/parallel_state.py
@@ -12,6 +12,9 @@ import vllm.distributed.parallel_state as P
 _ENABLE_CUSTOM_ALL_REDUCE = True
 USE_DHT = False
 NODE_PORT = ''
+IN_AUTODL = False
+AUTODL_WORKER_NUM = 0
+AUTODL_SERVER_IP_MAP = []
 
 #_TP: Optional[GroupCoordinator] = None
 #_PP: Optional[GroupCoordinator] = None

--- a/molink/engine/arg_utils.py
+++ b/molink/engine/arg_utils.py
@@ -30,6 +30,16 @@ class MolinkEngineArgs(AsyncEngineArgs):
             type=bool,
             default=False)
         
+        parser.add_argument(
+            '--in-autodl',
+            type=bool,
+            default=False)
+        
+        parser.add_argument(
+            '--autodl-worker-num',
+            type=int,
+            default=0)
+
         return parser
     
     @classmethod
@@ -42,6 +52,8 @@ class MolinkEngineArgs(AsyncEngineArgs):
         engine_args.serving_layers = args.serving_layers
         engine_args.use_dht = args.use_dht
         engine_args.port = args.port
+        engine_args.in_autodl = args.in_autodl
+        engine_args.autodl_worker_num = args.autodl_worker_num
         return engine_args
     
     def create_engine_config(self,

--- a/molink/engine/molink_engine.py
+++ b/molink/engine/molink_engine.py
@@ -182,8 +182,16 @@ class MolinkEngine(AsyncLLMEngine):
         serving_layers = kwargs.get('serving_layers')
         use_dht = kwargs.get('use_dht')
         port = kwargs.get('port')
+        in_autodl = kwargs.get('in_autodl')
+        autodl_worker_num = kwargs.get('autodl_worker_num')
         P.USE_DHT = use_dht
         P.NODE_PORT = port
+        P.IN_AUTODL = in_autodl
+        P.AUTODL_WORKER_NUM = autodl_worker_num
+        base_port = 38000
+        for i in range(autodl_worker_num):
+            P.AUTODL_SERVER_IP_MAP.append(f'localhost:{base_port + i}')
+            
         model_config = config.model_config
         num_all_layers = model_config.hf_config.num_hidden_layers
         layers_range = [0, num_all_layers - 1]
@@ -209,6 +217,8 @@ class MolinkEngine(AsyncLLMEngine):
         del kwargs['initial_peer']
         del kwargs['serving_layers']
         del kwargs['use_dht']
+        del kwargs['port']
+        del kwargs['in_autodl']
 
         super().__init__(*args, **kwargs)
     
@@ -244,5 +254,9 @@ class MolinkEngine(AsyncLLMEngine):
             stat_loggers=stat_loggers,
             initial_peer = engine_args.initial_peer,
             serving_layers = engine_args.serving_layers,
+            use_dht = engine_args.use_dht,
+            port = engine_args.port,
+            in_autodl = engine_args.in_autodl,
+            autodl_worker_num = engine_args.autodl_worker_num,
         )
         return engine

--- a/molink/entrypoints/api_server.py
+++ b/molink/entrypoints/api_server.py
@@ -64,7 +64,7 @@ async def join(request: Request) -> Response:
         head_info.update({'head':node_ip})
     node_start_layer = request_dict.get('start_layer')
     node_pool.update({node_ip : node_start_layer})
-    return {'status' : 'Successfully Connected'}
+    return JSONResponse({'status' : 'Successfully Connected'})
 
 @app.post("/grpc")
 async def join(request: Request) -> Response:
@@ -72,7 +72,9 @@ async def join(request: Request) -> Response:
     grpc_metadata = {'head' : head_ip}
     sorted_ips = [ip for ip, _ in sorted(node_info.items(), key=lambda item: item[1])]
     grpc_metadata.update({'server_list' : sorted_ips})
-    return grpc_metadata
+    if len(grpc_metadata) <= 0:
+        return JSONResponse({'response' : 'no content'})
+    return JSONResponse(grpc_metadata)
 
 
 @with_cancellation


### PR DESCRIPTION
This update adds support of this new feature: molink can be deployed on diffrent instances on autoDL, supporting instances that are in or not in the same area, and GPUs on these instances can be heterogeneous